### PR TITLE
feat: add MAINTENERS

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -1,0 +1,12 @@
+# Archivo MAINTAINERS
+
+## Desarrollo
+- Bryan Salazar (@SalazarBryan13)
+- Francisco Tamayo (@F0Moreno)
+
+## Pruebas y Calidad
+- Sebastián Correa (@SebasC02)
+- Brandon Jaya (@BrandonJaya)
+
+## Requerimientos, Arquitectura y Diseño
+- Juan Suárez (@juansuarezb)


### PR DESCRIPTION
Agregar archivo MAINTAINERS

**¿Cuál es el cambio?:**
Se agrega un archivo MAINTAINERS que lista a los integrantes del equipo y sus roles para mejorar la claridad y organización del proyecto.

**¿Por qué hacer este cambio?:**
Incluir un archivo MAINTAINERS mejora la visibilidad de las responsabilidades dentro del equipo. También se alinea con las buenas prácticas promovidas por GitHub para proyectos colaborativos, incluso en contextos académicos.

Este archivo documenta quién es responsable de cada parte del proyecto, lo cual facilita a cualquier colaborador o revisor saber a quién dirigirse en caso de dudas o propuestas.

**Plan de prueba:**
Verificado que el archivo se visualiza correctamente en el repositorio.